### PR TITLE
Reloadable CronSchedule

### DIFF
--- a/Pilgaard.BackgroundJobs.sln
+++ b/Pilgaard.BackgroundJobs.sln
@@ -47,7 +47,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pilgaard.RecurringJobs.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pilgaard.ScheduledJobs.Tests", "tests\Pilgaard.ScheduledJobs.Tests\Pilgaard.ScheduledJobs.Tests.csproj", "{8BD25B6F-AD7E-49CE-8810-DD111528096E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pilgaard.RecurringJobs.Examples.WorkerService", "samples\Pilgaard.RecurringJobs.Examples.WorkerService\Pilgaard.RecurringJobs.Examples.WorkerService.csproj", "{C196C530-F4D8-4F3B-B3D2-E07F67B62274}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pilgaard.RecurringJobs.Examples.WorkerService", "samples\Pilgaard.RecurringJobs.Examples.WorkerService\Pilgaard.RecurringJobs.Examples.WorkerService.csproj", "{C196C530-F4D8-4F3B-B3D2-E07F67B62274}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pilgaard.CronJobs.Examples.Configuration", "samples\Pilgaard.CronJobs.Examples.Configuration\Pilgaard.CronJobs.Examples.Configuration.csproj", "{2A6A61FD-F63E-4F04-8989-F46CBFD4FEF6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -95,6 +97,10 @@ Global
 		{C196C530-F4D8-4F3B-B3D2-E07F67B62274}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C196C530-F4D8-4F3B-B3D2-E07F67B62274}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C196C530-F4D8-4F3B-B3D2-E07F67B62274}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A6A61FD-F63E-4F04-8989-F46CBFD4FEF6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A6A61FD-F63E-4F04-8989-F46CBFD4FEF6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A6A61FD-F63E-4F04-8989-F46CBFD4FEF6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A6A61FD-F63E-4F04-8989-F46CBFD4FEF6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -110,6 +116,7 @@ Global
 		{DEE9D29B-64E5-48E8-BA85-46A0D14D7C75} = {AFBF3DFF-2BC5-47C9-A5B7-6CC93609FC4E}
 		{8BD25B6F-AD7E-49CE-8810-DD111528096E} = {AFBF3DFF-2BC5-47C9-A5B7-6CC93609FC4E}
 		{C196C530-F4D8-4F3B-B3D2-E07F67B62274} = {F80C4EC1-D73B-4602-9B01-BD98ECDE3905}
+		{2A6A61FD-F63E-4F04-8989-F46CBFD4FEF6} = {F80C4EC1-D73B-4602-9B01-BD98ECDE3905}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {AE30DB9E-1DB2-4346-9C9E-A487459AA94B}

--- a/samples/Pilgaard.CronJobs.Examples.Configuration/Pilgaard.CronJobs.Examples.Configuration.csproj
+++ b/samples/Pilgaard.CronJobs.Examples.Configuration/Pilgaard.CronJobs.Examples.Configuration.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetVersion)</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Pilgaard.CronJobs\Pilgaard.CronJobs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Pilgaard.CronJobs.Examples.Configuration/Program.cs
+++ b/samples/Pilgaard.CronJobs.Examples.Configuration/Program.cs
@@ -1,0 +1,11 @@
+using Pilgaard.CronJobs.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddCronJobs(typeof(Program));
+
+var app = builder.Build();
+
+app.MapGet("/", () => "Hello World!");
+
+app.Run();

--- a/samples/Pilgaard.CronJobs.Examples.Configuration/Properties/launchSettings.json
+++ b/samples/Pilgaard.CronJobs.Examples.Configuration/Properties/launchSettings.json
@@ -1,0 +1,13 @@
+{
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7067;http://localhost:5034",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/Pilgaard.CronJobs.Examples.Configuration/ReloadableCronJob.cs
+++ b/samples/Pilgaard.CronJobs.Examples.Configuration/ReloadableCronJob.cs
@@ -1,0 +1,30 @@
+using Cronos;
+
+namespace Pilgaard.CronJobs.Examples.Configuration;
+
+public class ReloadableCronJob : ICronJob
+{
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<ReloadableCronJob> _logger;
+
+    public ReloadableCronJob(IConfiguration configuration, ILogger<ReloadableCronJob> logger)
+    {
+        _configuration = configuration;
+        _logger = logger;
+    }
+
+    public Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("ReloadableCronJob.CronSchedule: {cronSchedule}", CronSchedule);
+
+        return Task.CompletedTask;
+    }
+
+    public CronExpression CronSchedule =>
+        CronExpression.Parse(
+            _configuration.GetValue<string>("ReloadableCronJob:CronSchedule"),
+            _configuration.GetValue<CronFormat>("ReloadableCronJob:CronFormat"));
+
+    public TimeZoneInfo TimeZoneInfo => TimeZoneInfo.Local;
+    public ServiceLifetime ServiceLifetime => ServiceLifetime.Transient;
+}

--- a/samples/Pilgaard.CronJobs.Examples.Configuration/appsettings.Development.json
+++ b/samples/Pilgaard.CronJobs.Examples.Configuration/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/samples/Pilgaard.CronJobs.Examples.Configuration/appsettings.json
+++ b/samples/Pilgaard.CronJobs.Examples.Configuration/appsettings.json
@@ -1,0 +1,13 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ReloadableCronJob": {
+    "CronSchedule": "5,30,50 * * * * *",
+    "CronFormat": "IncludeSeconds"
+  }
+}

--- a/src/Pilgaard.CronJobs/CronBackgroundService.cs
+++ b/src/Pilgaard.CronJobs/CronBackgroundService.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.Metrics;
-using Cronos;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -23,7 +22,6 @@ public class CronBackgroundService : BackgroundService
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly ICronJob _job;
     private readonly ILogger<CronBackgroundService> _logger;
-    private readonly CronExpression _cronSchedule;
     private readonly string _jobName;
 
     private static readonly Meter _meter = new(
@@ -51,8 +49,6 @@ public class CronBackgroundService : BackgroundService
         _logger = logger;
         _job = job;
         _jobName = _job.GetType().Name;
-        _cronSchedule = _job.CronSchedule;
-
 
         _logger.LogInformation("Started {className} with Job {job}",
             nameof(CronBackgroundService), _jobName);
@@ -102,7 +98,6 @@ public class CronBackgroundService : BackgroundService
         // CronJob from the ServiceProvider on every execution.
         if (_job.ServiceLifetime is not ServiceLifetime.Singleton)
         {
-
             _logger.LogDebug("Fetching a {serviceLifetime} instance of {jobName} from the ServiceProvider.",
                 _job.ServiceLifetime,
                 _jobName);
@@ -132,7 +127,7 @@ public class CronBackgroundService : BackgroundService
     ///     <see cref="ICronJob.ExecuteAsync"/> should trigger.
     /// </returns>
     private DateTime? GetNextOccurrence()
-        => _cronSchedule.GetNextOccurrence(DateTime.UtcNow, _job.TimeZoneInfo);
+        => _job.CronSchedule.GetNextOccurrence(DateTime.UtcNow, _job.TimeZoneInfo);
 
     /// <summary>
     ///     Checks whether the <paramref name="nextTaskExecution"/> is before

--- a/src/Pilgaard.CronJobs/CronBackgroundService.cs
+++ b/src/Pilgaard.CronJobs/CronBackgroundService.cs
@@ -20,7 +20,7 @@ namespace Pilgaard.CronJobs;
 public class CronBackgroundService : BackgroundService
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
-    private readonly ICronJob _job;
+    private readonly ICronJob _cronJob;
     private readonly ILogger<CronBackgroundService> _logger;
     private readonly string _jobName;
 
@@ -37,20 +37,20 @@ public class CronBackgroundService : BackgroundService
     /// <summary>
     /// Initializes a new instance of the <see cref="CronBackgroundService"/> class.
     /// </summary>
-    /// <param name="job">The cron job.</param>
+    /// <param name="cronJob">The cronJob.</param>
     /// <param name="serviceScopeFactory">The service scope factory.</param>
     /// <param name="logger">The logger.</param>
     public CronBackgroundService(
-        ICronJob job,
+        ICronJob cronJob,
         IServiceScopeFactory serviceScopeFactory,
         ILogger<CronBackgroundService> logger)
     {
         _serviceScopeFactory = serviceScopeFactory;
         _logger = logger;
-        _job = job;
-        _jobName = _job.GetType().Name;
+        _cronJob = cronJob;
+        _jobName = _cronJob.GetType().Name;
 
-        _logger.LogInformation("Started {className} with Job {job}",
+        _logger.LogInformation("Started {className} with Job {jobName}",
             nameof(CronBackgroundService), _jobName);
     }
 
@@ -96,15 +96,15 @@ public class CronBackgroundService : BackgroundService
 
         // If ServiceLifetime is Transient or Scoped, we need to re-fetch the
         // CronJob from the ServiceProvider on every execution.
-        if (_job.ServiceLifetime is not ServiceLifetime.Singleton)
+        if (_cronJob.ServiceLifetime is not ServiceLifetime.Singleton)
         {
             _logger.LogDebug("Fetching a {serviceLifetime} instance of {jobName} from the ServiceProvider.",
-                _job.ServiceLifetime,
+                _cronJob.ServiceLifetime,
                 _jobName);
 
             using var scope = _serviceScopeFactory.CreateScope();
 
-            var cronJob = (ICronJob)scope.ServiceProvider.GetRequiredService(_job.GetType());
+            var cronJob = (ICronJob)scope.ServiceProvider.GetRequiredService(_cronJob.GetType());
 
             await cronJob.ExecuteAsync(stoppingToken).ConfigureAwait(false);
 
@@ -113,7 +113,7 @@ public class CronBackgroundService : BackgroundService
             return;
         }
 
-        await _job.ExecuteAsync(stoppingToken).ConfigureAwait(false);
+        await _cronJob.ExecuteAsync(stoppingToken).ConfigureAwait(false);
 
         _logger.LogDebug("Successfully executed the Job {jobName}", _jobName);
     }
@@ -127,7 +127,7 @@ public class CronBackgroundService : BackgroundService
     ///     <see cref="ICronJob.ExecuteAsync"/> should trigger.
     /// </returns>
     private DateTime? GetNextOccurrence()
-        => _job.CronSchedule.GetNextOccurrence(DateTime.UtcNow, _job.TimeZoneInfo);
+        => _cronJob.CronSchedule.GetNextOccurrence(DateTime.UtcNow, _cronJob.TimeZoneInfo);
 
     /// <summary>
     ///     Checks whether the <paramref name="nextTaskExecution"/> is before


### PR DESCRIPTION
CronSchedule is no longer cached
This means it can be updated when it's read through appsettings, for example. 

The Sample `Pilgaard.CronJobs.Examples.Configuration` showcases this.
