### PR TITLE
Allow omitting name when registering jobs by type

### DIFF
--- a/src/Pilgaard.BackgroundJobs/Registration/BackgroundJobsBuilderExtensions.cs
+++ b/src/Pilgaard.BackgroundJobs/Registration/BackgroundJobsBuilderExtensions.cs
@@ -11,22 +11,21 @@ public static class BackgroundJobsBuilderExtensions
     /// Adds a background job of type <typeparamref name="TJob"/> to the <see cref="IBackgroundJobsBuilder"/>.
     /// </summary>
     /// <param name="builder">The builder.</param>
-    /// <param name="name">The name to use for the job.</param>
+    /// <param name="name">The name to use for the job. Uses the name of <typeparamref name="TJob"/> if <paramref name="name"/> is <c>null</c>.</param>
     /// <param name="timeout">The timeout of the job, defaults to no timeout.</param>
     /// <exception cref="ArgumentNullException">Throws if either <paramref name="builder"/> or <paramref name="name"/> is <c>null</c></exception>
     /// <returns>The <see cref="IBackgroundJobsBuilder"/> for further chaining.</returns>
     public static IBackgroundJobsBuilder AddJob<TJob>(
         this IBackgroundJobsBuilder builder,
-        string name,
+        string? name = null,
         TimeSpan? timeout = default) where TJob : class, IBackgroundJob
     {
         if (builder is null)
             throw new ArgumentNullException(nameof(builder));
 
-        if (name is null)
-            throw new ArgumentNullException(nameof(name));
 
-        return builder.Add(new BackgroundJobRegistration(GetServiceOrCreateInstance, name, timeout));
+
+        return builder.Add(new BackgroundJobRegistration(GetServiceOrCreateInstance, name ?? typeof(TJob).Name, timeout));
 
         static TJob GetServiceOrCreateInstance(IServiceProvider serviceProvider) =>
             ActivatorUtilities.GetServiceOrCreateInstance<TJob>(serviceProvider);

--- a/tests/Pilgaard.BackgroundJobs.Tests/Pilgaard.BackgroundJobs.approved.txt
+++ b/tests/Pilgaard.BackgroundJobs.Tests/Pilgaard.BackgroundJobs.approved.txt
@@ -29,7 +29,7 @@
     }
     public static class BackgroundJobsBuilderExtensions
     {
-        public static Pilgaard.BackgroundJobs.IBackgroundJobsBuilder AddJob<TJob>(this Pilgaard.BackgroundJobs.IBackgroundJobsBuilder builder, string name, System.TimeSpan? timeout = default)
+        public static Pilgaard.BackgroundJobs.IBackgroundJobsBuilder AddJob<TJob>(this Pilgaard.BackgroundJobs.IBackgroundJobsBuilder builder, string? name = null, System.TimeSpan? timeout = default)
             where TJob :  class, Pilgaard.BackgroundJobs.IBackgroundJob { }
     }
     public static class CronJobExtensions


### PR DESCRIPTION
I find that I often use `nameof(BackgroundJobClassName)` when registering jobs, I'm thinking that might as well be the default.
It can be overriden, like before.